### PR TITLE
Explicitly push mac and linux packages to cachix

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,8 +36,9 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Build
       run: nix build
-    - name: Push package to cache
+    - name: Try to push package to cache
       run: |
         nix build --json \
           | jq -r '.[].outputs | to_entries[].value' \
-          | cachix push papermario-dx
+          | cachix push papermario-dx \
+          || true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,10 @@ jobs:
     - name: Build
       run: ./gradlew createReleaseZip
   build-nix-flake:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -33,3 +36,8 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Build
       run: nix build
+    - name: Push package to cache
+      run: |
+        nix build --json \
+          | jq -r '.[].outputs | to_entries[].value' \
+          | cachix push papermario-dx


### PR DESCRIPTION
This fixes the build-nix-flake job so that it actually pushes the darwin-aarch64 and linux-x86_64 packages to Cachix